### PR TITLE
Support `net10.0`, remove `net6.0`, and upgrade packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: NuGet/setup-nuget@v2
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Read common.props
         id: commonProps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
             9.0.x
+            10.0.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
 
-        <GrpcVersion>2.71.0</GrpcVersion>
-        <GoogleProtobufVersion>3.32.0</GoogleProtobufVersion>
+        <GrpcVersion>2.80.0</GrpcVersion>
+        <GoogleProtobufVersion>3.35.1</GoogleProtobufVersion>
 
-        <EfCoreVersionForNet9>9.0.8</EfCoreVersionForNet9>
-        <EfCoreVersionForNet8>8.0.19</EfCoreVersionForNet8>
-        <EfCoreVersionForNet6>6.0.36</EfCoreVersionForNet6>
+        <EfCoreVersionForNet10>10.0.9</EfCoreVersionForNet10>
+        <EfCoreVersionForNet9>9.0.17</EfCoreVersionForNet9>
+        <EfCoreVersionForNet8>8.0.28</EfCoreVersionForNet8>
 
-        <DapperVersion>2.1.66</DapperVersion>
-        <MongoDbDriverVersion>3.4.3</MongoDbDriverVersion>
+        <DapperVersion>2.1.79</DapperVersion>
+        <MongoDbDriverVersion>3.9.0</MongoDbDriverVersion>
         <Mongo2GoVersion>4.1.0</Mongo2GoVersion>
 
-        <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
+        <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
 
-        <MicrosoftPackagesVersion>9.0.8</MicrosoftPackagesVersion>
-        <MicrosoftNetTestSdkVersion>17.13.0</MicrosoftNetTestSdkVersion>
+        <MicrosoftPackagesVersion>10.0.9</MicrosoftPackagesVersion>
+        <MicrosoftNetTestSdkVersion>18.6.0</MicrosoftNetTestSdkVersion>
 
-        <DistributedLockCoreVersion>1.0.8</DistributedLockCoreVersion>
+        <DistributedLockCoreVersion>1.0.9</DistributedLockCoreVersion>
 
     </PropertyGroup>
 </Project>

--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <Version>1.4.0</Version>
+        <Version>1.5.0</Version>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <Authors>Stepping</Authors>
         <Company>Stepping</Company>
@@ -17,7 +17,7 @@
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)/icon.png" Pack="true" PackagePath="/" Visible="false"/>
         <None Include="$(MSBuildThisFileDirectory)/docs/README.md" Pack="true" PackagePath="/" Visible="false"/>
-        <PackageReference Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All"/>
+        <PackageReference Include="ConfigureAwait.Fody" Version="3.4.1" PrivateAssets="All"/>
         <PackageReference Include="Fody" Version="6.9.3">
             <PrivateAssets>All</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common.testing.props
+++ b/common.testing.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Stepping.DbProviders.EfCore/Stepping.DbProviders.EfCore.csproj
+++ b/src/Stepping.DbProviders.EfCore/Stepping.DbProviders.EfCore.csproj
@@ -3,7 +3,7 @@
     <Import Project="..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace />
@@ -15,9 +15,9 @@
 
     <ItemGroup>
         <PackageReference Include="Dapper" Version="$(DapperVersion)" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet10)" Condition="'$(TargetFramework)' == 'net10.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet9)" Condition="'$(TargetFramework)' == 'net9.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet8)" Condition="'$(TargetFramework)' == 'net8.0'"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet6)" Condition="'$(TargetFramework)' == 'net6.0'"/>
     </ItemGroup>
 
 </Project>

--- a/src/Stepping.TmProviders.Dtm.Grpc/Stepping/TmProviders/Dtm/Grpc/TransactionManagers/DtmGrpcTmClient.cs
+++ b/src/Stepping.TmProviders.Dtm.Grpc/Stepping/TmProviders/Dtm/Grpc/TransactionManagers/DtmGrpcTmClient.cs
@@ -95,7 +95,7 @@ public class DtmGrpcTmClient : ITmClient
     {
         var configurations = job.GetDtmJobConfigurations();
 
-        if (Options.ActionApiToken is not null or "")
+        if (Options.ActionApiToken is not (null or ""))
         {
             configurations.BranchHeaders.TryAdd(DtmRequestHeaderNames.ActionApiToken, Options.ActionApiToken);
         }

--- a/src/Stepping.TmProviders.LocalTm.EfCore/Stepping.TmProviders.LocalTm.EfCore.csproj
+++ b/src/Stepping.TmProviders.LocalTm.EfCore/Stepping.TmProviders.LocalTm.EfCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace />
@@ -14,9 +14,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet10)" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet9)" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet8)" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfCoreVersionForNet6)" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
   
 </Project>

--- a/src/Stepping.TmProviders.LocalTm.HostedServiceProcessor/Stepping.TmProviders.LocalTm.HostedServiceProcessor.csproj
+++ b/src/Stepping.TmProviders.LocalTm.HostedServiceProcessor/Stepping.TmProviders.LocalTm.HostedServiceProcessor.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace />

--- a/src/Stepping.TmProviders.LocalTm/Stepping.TmProviders.LocalTm.csproj
+++ b/src/Stepping.TmProviders.LocalTm/Stepping.TmProviders.LocalTm.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace />

--- a/test/Stepping.DbProviders.EfCore.Tests/Stepping.DbProviders.EfCore.Tests.csproj
+++ b/test/Stepping.DbProviders.EfCore.Tests/Stepping.DbProviders.EfCore.Tests.csproj
@@ -3,9 +3,9 @@
     <Import Project="..\..\common.testing.props"/>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet10)" Condition="'$(TargetFramework)' == 'net10.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet9)" Condition="'$(TargetFramework)' == 'net9.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet8)" Condition="'$(TargetFramework)' == 'net8.0'"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet6)" Condition="'$(TargetFramework)' == 'net6.0'"/>
 
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)"/>
         <ProjectReference Include="..\..\src\Stepping.DbProviders.EfCore\Stepping.DbProviders.EfCore.csproj"/>

--- a/test/Stepping.TestBase/Stepping.TestBase.csproj
+++ b/test/Stepping.TestBase/Stepping.TestBase.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Shouldly" Version="4.3.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.extensibility.execution" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
         <ProjectReference Include="..\..\src\Stepping.Core\Stepping.Core.csproj"/>
     </ItemGroup>
 

--- a/test/Stepping.TmProviders.Dtm.Grpc.TestApp/Stepping.TmProviders.Dtm.Grpc.TestApp.csproj
+++ b/test/Stepping.TmProviders.Dtm.Grpc.TestApp/Stepping.TmProviders.Dtm.Grpc.TestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 

--- a/test/Stepping.TmProviders.Dtm.Grpc.Tests/Tests/DtmGrpcTmClientTests.cs
+++ b/test/Stepping.TmProviders.Dtm.Grpc.Tests/Tests/DtmGrpcTmClientTests.cs
@@ -132,4 +132,37 @@ public class DtmGrpcTmClientTests : SteppingTmProvidersDtmGrpcTestBase
         dtmRequest.TransOptions.WaitResult.ShouldBeTrue();
         dtmRequest.TransOptions.RequestTimeout.ShouldBe(Options.BranchRequestTimeout);
     }
+
+    [Fact]
+    public async Task Should_Add_ActionApiToken_Header_When_Configured()
+    {
+        Options.ActionApiToken = "my-action-api-token";
+
+        var job = await AtomicJobFactory.CreateJobAsync(Guid.NewGuid().ToString(),
+            new FakeSteppingDbContext(true));
+        job.AddStep<FakeExecutableStep>();
+
+        await FakeDtmGrpcTmClient.PrepareAsync(job);
+
+        var headers = FakeDtmGrpcTmClient.LastInvoking!.Value.Item2.TransOptions.BranchHeaders;
+        headers.ShouldContainKey(DtmRequestHeaderNames.ActionApiToken);
+        headers[DtmRequestHeaderNames.ActionApiToken].ShouldBe("my-action-api-token");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Should_Not_Add_ActionApiToken_Header_When_Not_Configured(string? actionApiToken)
+    {
+        Options.ActionApiToken = actionApiToken;
+
+        var job = await AtomicJobFactory.CreateJobAsync(Guid.NewGuid().ToString(),
+            new FakeSteppingDbContext(true));
+        job.AddStep<FakeExecutableStep>();
+
+        await FakeDtmGrpcTmClient.PrepareAsync(job);
+
+        var headers = FakeDtmGrpcTmClient.LastInvoking!.Value.Item2.TransOptions.BranchHeaders;
+        headers.ShouldNotContainKey(DtmRequestHeaderNames.ActionApiToken);
+    }
 }

--- a/test/Stepping.TmProviders.LocalTm.EfCore.Tests/Stepping.TmProviders.LocalTm.EfCore.Tests.csproj
+++ b/test/Stepping.TmProviders.LocalTm.EfCore.Tests/Stepping.TmProviders.LocalTm.EfCore.Tests.csproj
@@ -3,9 +3,9 @@
     <Import Project="..\..\common.testing.props"/>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet10)" Condition="'$(TargetFramework)' == 'net10.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet9)" Condition="'$(TargetFramework)' == 'net9.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet8)" Condition="'$(TargetFramework)' == 'net8.0'"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet6)" Condition="'$(TargetFramework)' == 'net6.0'"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)"/>
         <ProjectReference Include="..\..\src\Stepping.TmProviders.LocalTm.EfCore\Stepping.TmProviders.LocalTm.EfCore.csproj"/>
         <ProjectReference Include="..\Stepping.TestBase\Stepping.TestBase.csproj"/>

--- a/test/Stepping.TmProviders.LocalTm.TestApp/Stepping.TmProviders.LocalTm.TestApp.csproj
+++ b/test/Stepping.TmProviders.LocalTm.TestApp/Stepping.TmProviders.LocalTm.TestApp.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet10)" Condition="'$(TargetFramework)' == 'net10.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet9)" Condition="'$(TargetFramework)' == 'net9.0'"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet8)" Condition="'$(TargetFramework)' == 'net8.0'"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EfCoreVersionForNet6)" Condition="'$(TargetFramework)' == 'net6.0'"/>
         <ProjectReference Include="..\..\src\Stepping.TmProviders.LocalTm.EfCore\Stepping.TmProviders.LocalTm.EfCore.csproj" />
         <ProjectReference Include="..\..\src\Stepping.TmProviders.LocalTm\Stepping.TmProviders.LocalTm.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

- Add **.NET 10** support and drop **.NET 6**. Multi-target projects now build for `net10.0;net9.0;net8.0` (the `netstandard2.1` core libraries are unchanged).
- Upgrade .NET 8/9 and library dependencies to the latest stable versions to keep the matrix consistent and error-free.

## Target frameworks

`net9.0;net8.0;net6.0` → `net10.0;net9.0;net8.0` across all multi-target src/test projects and `common.testing.props`.

## Dependency updates (`Directory.Build.props`)

| Package | Old | New |
|---|---|---|
| EF Core (net10) | — | **10.0.9** (new) |
| EF Core (net9) | 9.0.8 | 9.0.17 |
| EF Core (net8) | 8.0.19 | 8.0.28 |
| EF Core (net6) | 6.0.36 | **removed** |
| Microsoft.Extensions.* | 9.0.8 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 17.13.0 | 18.6.0 |
| Grpc | 2.71.0 | 2.80.0 |
| Google.Protobuf | 3.32.0 | 3.35.1 |
| Dapper | 2.1.66 | 2.1.79 |
| MongoDB.Driver | 3.4.3 | 3.9.0 |
| Newtonsoft.Json | 13.0.3 | 13.0.4 |
| DistributedLock.Core | 1.0.8 | 1.0.9 |

Also: package version 1.4.0 → **1.5.0**, ConfigureAwait.Fody 3.4.1, coverlet.collector 6.0.4 → 10.0.1, xunit.runner.visualstudio 3.1.4 → 3.1.5.

> Verified `Microsoft.Extensions.*` 10.0.9 still ships `netstandard2.0/2.1` targets, so the `netstandard2.1` core libraries remain compatible.

## CI workflows

- `test.yml`: installed SDKs `6.0.x/7.0.x/9.0.x` → `8.0.x/9.0.x/10.0.x`
- `publish.yml`: `9.0.x` → `10.0.x`

## Incidental fix

The C# 14 analyzer surfaced `CS9336` in `DtmGrpcTmClient.cs`: `is not null or ""` parses as `(is not null) or (is "")`, i.e. just `is not null` — the `or ""` was dead code, contrary to the apparent intent ("not null **and** not empty"). Changed to `is not (null or "")`. **Note:** this changes runtime behavior for an empty-string `ActionApiToken` (the header is no longer added).

## Testing

- `dotnet build` (Debug & Release): 0 errors.
- All tests pass on **net10.0** and **net8.0** (106 each). net9.0 compiles but wasn't run locally (runtime not installed); CI covers all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)